### PR TITLE
Update index.js (registerBufferProtocol)

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,7 @@ const getPath = url => {
  * @param {Object} locals pug locals
  * @returns {Promise} promise resolving to PugEmitter
  */
-const setupPug = (options = {}, locals) => (
-  new Promise((resolve, reject) => {
+const setupPug = (options = {}, locals) => {
     let emitter = new PugEmitter()
 
     protocol.interceptBufferProtocol('file', (request, result) => {
@@ -82,8 +81,7 @@ const setupPug = (options = {}, locals) => (
         emitter.emit('error', err)
         return result(errorData)
       }
-    }, err => err ? reject(err) : resolve(emitter))
-  })
-)
+    })
+}
 
 module.exports = setupPug


### PR DESCRIPTION
According to Electron's Breaking changes document, registerBufferProtocol is now synchronous, so calling it has actually got simpler, I've gone ahead and updated the index.js to support these new changes, and to avoid "ProtocolDeprecateCallback: The callback argument of protocol module APIs is no longer needed." error from appearing up in console.