### PR TITLE
Update README.md (registerBufferProtocol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ const setupPug = require('electron-pug')
 app.on('ready', async () => {
   try {
     let pug = await setupPug({pretty: true}, locals)
-    pug.on('error', err => console.error('electron-pug error', err))
   } catch (err) {
     // Could not initiate 'electron-pug'
   }


### PR DESCRIPTION
Recap: I've gone ahead and updated the index.js to support new changes, and to avoid "ProtocolDeprecateCallback: The callback argument of protocol module APIs is no longer needed." error from appearing up in console. Update: The new changes no longer support "pug.on('error', err => console.error('electron-pug error', err))"  so I've also gone ahead and updated the readme.md to support these new changes.